### PR TITLE
Migrate ATVersionControl to Swift 6 and Networking V2

### DIFF
--- a/ATVersionControl.podspec
+++ b/ATVersionControl.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'ATVersionControl'
-  s.version          = '0.6.0'
+  s.version          = '0.7.0'
   s.summary          = 'Version control library for AyanTech iOS apps'
   s.description      = <<-DESC
 Library to check for new version of app with AyanTech servers

--- a/ATVersionControl.podspec
+++ b/ATVersionControl.podspec
@@ -19,8 +19,8 @@ Library to check for new version of app with AyanTech servers
   s.source           = { :git => 'https://github.com/AyanTech/ATVersionControl-iOS.git', :tag => s.version.to_s }
   s.social_media_url = 'https://twitter.com/3pehrbehroozi'
 
-  s.ios.deployment_target = '11.0'
-  s.swift_version = "5.0"
+  s.ios.deployment_target = '13.0'
+  s.swift_version = "6.0"
   s.source_files = 'ATVersionControl/Classes/**/*'
   
   s.frameworks = 'UIKit', 'Foundation'

--- a/ATVersionControl.podspec
+++ b/ATVersionControl.podspec
@@ -24,6 +24,5 @@ Library to check for new version of app with AyanTech servers
   s.source_files = 'ATVersionControl/Classes/**/*'
   
   s.frameworks = 'UIKit', 'Foundation'
-  s.dependency 'PopupDialog'
   s.dependency 'AyanTechNetworkingLibrary', '~> 2.0'
 end

--- a/ATVersionControl.podspec
+++ b/ATVersionControl.podspec
@@ -24,7 +24,6 @@ Library to check for new version of app with AyanTech servers
   s.source_files = 'ATVersionControl/Classes/**/*'
   
   s.frameworks = 'UIKit', 'Foundation'
-  s.dependency 'SwiftBooster'
   s.dependency 'PopupDialog'
   s.dependency 'AyanTechNetworkingLibrary', '~> 2.0'
 end

--- a/ATVersionControl.podspec
+++ b/ATVersionControl.podspec
@@ -26,5 +26,5 @@ Library to check for new version of app with AyanTech servers
   s.frameworks = 'UIKit', 'Foundation'
   s.dependency 'SwiftBooster'
   s.dependency 'PopupDialog'
-  s.dependency 'AyanTechNetworkingLibrary'
+  s.dependency 'AyanTechNetworkingLibrary', '~> 2.0'
 end

--- a/ATVersionControl/Classes/Combine/ColocationClient.swift
+++ b/ATVersionControl/Classes/Combine/ColocationClient.swift
@@ -1,0 +1,129 @@
+//
+//  ColocationClient.swift
+//  ATVersionControl
+//
+
+import AyanTechNetworkingLibrary
+import Combine
+import Foundation
+
+struct ColocationClient: Sendable {
+    struct URLs: Sendable {
+        let iran: String
+        let international: String
+    }
+
+    private struct Request: Encodable, Sendable {
+        let applicationName: String
+        let applicationType = "ios"
+        let colocationType: String
+        let currentApplicationVersion: String
+
+        enum CodingKeys: String, CodingKey {
+            case applicationName = "ApplicationName"
+            case applicationType = "ApplicationType"
+            case colocationType = "ColocationType"
+            case currentApplicationVersion = "CurrentApplicationVersion"
+        }
+    }
+
+    private enum Lane: Sendable {
+        case iran
+        case international
+
+        var type: String {
+            switch self {
+            case .iran:
+                return "Iran1"
+            case .international:
+                return "International"
+            }
+        }
+    }
+
+    private static let cacheKey = "ATVersionControl.cache.colocationType"
+
+    private let urls: URLs
+    private let configuration: ConfigurationV2
+
+    init(urls: URLs, configuration: ConfigurationV2 = .init()) {
+        self.urls = urls
+        self.configuration = configuration
+    }
+
+    func getEndpoints(
+        applicationName: String,
+        version: String
+    ) -> AnyPublisher<[ColocationEndpoint], ATErrorV2> {
+        getEndpoints(
+            lanes: lanesInTryOrder(),
+            applicationName: applicationName,
+            version: version
+        )
+    }
+
+    private func getEndpoints(
+        lanes: [Lane],
+        applicationName: String,
+        version: String
+    ) -> AnyPublisher<[ColocationEndpoint], ATErrorV2> {
+        guard let lane = lanes.first else {
+            return Fail(error: ATErrorV2(errorType: .general))
+                .eraseToAnyPublisher()
+        }
+
+        let request = Request(
+            applicationName: applicationName,
+            colocationType: lane.type,
+            currentApplicationVersion: version
+        )
+
+        return ATRequestV2(
+            url: url(for: lane),
+            parameters: request,
+            configuration: configuration
+        )
+        .valuePublisher(ColocationInfo.self)
+        .tryMap { info in
+            let endpoints = info.endpoints
+            guard !endpoints.isEmpty else {
+                throw ATErrorV2(errorType: .serialization)
+            }
+
+            UserDefaults.standard.set(lane.type, forKey: Self.cacheKey)
+            return endpoints
+        }
+        .mapError(ATErrorV2.from)
+        .catch { error in
+            guard case .cancelled = error.errorType else {
+                return getEndpoints(
+                    lanes: Array(lanes.dropFirst()),
+                    applicationName: applicationName,
+                    version: version
+                )
+            }
+
+            return Fail<[ColocationEndpoint], ATErrorV2>(error: error)
+                .eraseToAnyPublisher()
+        }
+        .eraseToAnyPublisher()
+    }
+
+    private func lanesInTryOrder() -> [Lane] {
+        switch UserDefaults.standard.string(forKey: Self.cacheKey) {
+        case Lane.international.type:
+            return [.international, .iran]
+        default:
+            return [.iran, .international]
+        }
+    }
+
+    private func url(for lane: Lane) -> String {
+        switch lane {
+        case .iran:
+            return urls.iran
+        case .international:
+            return urls.international
+        }
+    }
+}

--- a/ATVersionControl/Classes/Combine/VersionClient.swift
+++ b/ATVersionControl/Classes/Combine/VersionClient.swift
@@ -1,0 +1,116 @@
+//
+//  VersionClient.swift
+//  ATVersionControl
+//
+
+import AyanTechNetworkingLibrary
+import Combine
+
+struct VersionClient: Sendable {
+    struct URLs: Sendable {
+        let checkVersion: String
+        let getLastVersion: String
+    }
+
+    private struct VersionRequest: Encodable, Sendable {
+        let applicationName: String
+        let applicationType = "ios"
+        let categoryName: String
+        let currentApplicationVersion: String
+        let extraInfo: [String: String]
+
+        enum CodingKeys: String, CodingKey {
+            case applicationName = "ApplicationName"
+            case applicationType = "ApplicationType"
+            case categoryName = "CategoryName"
+            case currentApplicationVersion = "CurrentApplicationVersion"
+            case extraInfo = "ExtraInfo"
+        }
+    }
+
+    private struct CheckVersionResponse: Decodable, Sendable {
+        let updateStatus: UpdateStatus?
+
+        enum CodingKeys: String, CodingKey {
+            case updateStatus = "UpdateStatus"
+        }
+    }
+
+    private let urls: URLs
+    private let configuration: ConfigurationV2
+
+    init(urls: URLs, configuration: ConfigurationV2 = .init()) {
+        self.urls = urls
+        self.configuration = configuration
+    }
+
+    func checkVersion(
+        applicationName: String,
+        version: String,
+        categoryName: String,
+        extraInfo: [String: String]
+    ) -> AnyPublisher<(status: UpdateStatus, versionInfo: VersionInfo?), ATErrorV2> {
+        let request = VersionRequest(
+            applicationName: applicationName,
+            categoryName: categoryName,
+            currentApplicationVersion: version,
+            extraInfo: extraInfo
+        )
+
+        return ATRequestV2(
+            url: urls.checkVersion,
+            parameters: request,
+            configuration: configuration
+        )
+        .valuePublisher(CheckVersionResponse.self)
+        .tryMap { response in
+            guard let status = response.updateStatus else {
+                throw ATErrorV2(errorType: .serialization)
+            }
+            return status
+        }
+        .mapError(ATErrorV2.from)
+        .flatMap { status
+            -> AnyPublisher<(status: UpdateStatus, versionInfo: VersionInfo?), ATErrorV2> in
+            guard status != .notRequired else {
+                return Just((status: status, versionInfo: nil))
+                    .setFailureType(to: ATErrorV2.self)
+                    .eraseToAnyPublisher()
+            }
+
+            return getLastVersion(request)
+                .map { versionInfo in
+                    (status: status, versionInfo: Optional(versionInfo))
+                }
+                .eraseToAnyPublisher()
+        }
+        .eraseToAnyPublisher()
+    }
+
+    func getLastVersion(
+        applicationName: String,
+        version: String,
+        categoryName: String,
+        extraInfo: [String: String]
+    ) -> AnyPublisher<VersionInfo, ATErrorV2> {
+        getLastVersion(
+            VersionRequest(
+                applicationName: applicationName,
+                categoryName: categoryName,
+                currentApplicationVersion: version,
+                extraInfo: extraInfo
+            )
+        )
+    }
+
+    private func getLastVersion(
+        _ request: VersionRequest
+    ) -> AnyPublisher<VersionInfo, ATErrorV2> {
+        ATRequestV2(
+            url: urls.getLastVersion,
+            parameters: request,
+            configuration: configuration
+        )
+        .valuePublisher(VersionInfo.self)
+    }
+}

--- a/ATVersionControl/Classes/Combine/VersionControl+Publishers.swift
+++ b/ATVersionControl/Classes/Combine/VersionControl+Publishers.swift
@@ -91,7 +91,8 @@ public extension VersionControl {
             urls: VersionClient.URLs(
                 checkVersion: ATUrl.checkVersion,
                 getLastVersion: ATUrl.getLastVersion
-            )
+            ),
+            configuration: networkingConfiguration
         )
     }
 
@@ -100,7 +101,8 @@ public extension VersionControl {
             urls: ColocationClient.URLs(
                 iran: ATUrl.iranGetApplicationColocationConfig,
                 international: ATUrl.internationalGetApplicationColocationConfig
-            )
+            ),
+            configuration: networkingConfiguration
         )
     }
 }

--- a/ATVersionControl/Classes/Combine/VersionControl+Publishers.swift
+++ b/ATVersionControl/Classes/Combine/VersionControl+Publishers.swift
@@ -1,0 +1,97 @@
+//
+//  VersionControl+Publishers.swift
+//  ATVersionControl
+//
+
+import AyanTechNetworkingLibrary
+import Combine
+import UIKit
+
+public extension VersionControl {
+    func checkVersionPublisher() -> AnyPublisher<UpdateStatus, ATErrorV2> {
+        buildVersionClient().checkVersion(
+            applicationName: applicationName,
+            version: version,
+            categoryName: categoryName,
+            extraInfo: extraInfo
+        )
+        .receive(on: DispatchQueue.main)
+        .handleEvents(receiveOutput: { [weak self] result in
+            guard let versionInfo = result.versionInfo else {
+                return
+            }
+
+            MainActor.assumeIsolated {
+                self?.showUpdateDialog(
+                    updateStatus: result.status,
+                    versionInfo: versionInfo
+                )
+            }
+        })
+        .map(\.status)
+        .eraseToAnyPublisher()
+    }
+
+    func getLastVersionPublisher() -> AnyPublisher<VersionInfo, ATErrorV2> {
+        buildVersionClient().getLastVersion(
+            applicationName: applicationName,
+            version: version,
+            categoryName: categoryName,
+            extraInfo: extraInfo
+        )
+    }
+
+    func getEndpointsPublisher() -> AnyPublisher<[ColocationEndpoint], ATErrorV2> {
+        buildColocationClient()
+            .getEndpoints(applicationName: applicationName, version: version)
+            .receive(on: DispatchQueue.main)
+            .handleEvents(
+                receiveOutput: { endpoints in
+                    MainActor.assumeIsolated {
+                        ATUrl.versionControlBaseURL = endpoints
+                            .first(where: { $0.name == "VersionControl" })?
+                            .baseURL ?? ATUrl.defaultVersionControlBaseURL
+                    }
+                },
+                receiveCompletion: { completion in
+                    guard case .failure = completion else { return }
+                    MainActor.assumeIsolated {
+                        ATUrl.versionControlBaseURL = ATUrl.defaultVersionControlBaseURL
+                    }
+                }
+            )
+            .eraseToAnyPublisher()
+    }
+
+    func shareAppLinkPublisher() -> AnyPublisher<Void, ATErrorV2> {
+        getLastVersionPublisher()
+            .map(\.textToShare)
+            .receive(on: DispatchQueue.main)
+            .handleEvents(receiveOutput: { textToShare in
+                MainActor.assumeIsolated {
+                    let activity = UIActivityViewController(activityItems: [textToShare], applicationActivities: nil)
+                    Utils.getTopMostViewController()?.present(activity, animated: true)
+                }
+            })
+            .map { _ in () }
+            .eraseToAnyPublisher()
+    }
+
+    private func buildVersionClient() -> VersionClient {
+        VersionClient(
+            urls: VersionClient.URLs(
+                checkVersion: ATUrl.checkVersion,
+                getLastVersion: ATUrl.getLastVersion
+            )
+        )
+    }
+
+    private func buildColocationClient() -> ColocationClient {
+        ColocationClient(
+            urls: ColocationClient.URLs(
+                iran: ATUrl.iranGetApplicationColocationConfig,
+                international: ATUrl.internationalGetApplicationColocationConfig
+            )
+        )
+    }
+}

--- a/ATVersionControl/Classes/Combine/VersionControl+Publishers.swift
+++ b/ATVersionControl/Classes/Combine/VersionControl+Publishers.swift
@@ -70,7 +70,16 @@ public extension VersionControl {
             .handleEvents(receiveOutput: { textToShare in
                 MainActor.assumeIsolated {
                     let activity = UIActivityViewController(activityItems: [textToShare], applicationActivities: nil)
-                    Utils.getTopMostViewController()?.present(activity, animated: true)
+                    guard let viewController = Utils.getTopMostViewController() else { return }
+                    activity.popoverPresentationController?.sourceView = viewController.view
+                    activity.popoverPresentationController?.sourceRect = CGRect(
+                        x: viewController.view.bounds.midX,
+                        y: viewController.view.bounds.midY,
+                        width: 0,
+                        height: 0
+                    )
+                    activity.popoverPresentationController?.permittedArrowDirections = []
+                    viewController.present(activity, animated: true)
                 }
             })
             .map { _ in () }

--- a/ATVersionControl/Classes/Model/ATUrl.swift
+++ b/ATVersionControl/Classes/Model/ATUrl.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+@MainActor
 class ATUrl {
     static let defaultVersionControlBaseURL = "https://versioncontrol.infra.ayantech.ir/WebServices/App.svc/"
     static let internationalVersionControlBaseURL = "https://versioncontrol.infra.ayanco.com/WebServices/App.svc/"

--- a/ATVersionControl/Classes/Model/Colocation.swift
+++ b/ATVersionControl/Classes/Model/Colocation.swift
@@ -12,10 +12,15 @@ import AyanTechNetworkingLibrary
 /// - Cache only affects try order on the next call; each resolve still performs network requests.
 /// - On success: sets ATUrl.versionControlBaseURL from the VersionControl endpoint (or default), caches lane type.
 /// - On failure (both lanes): resets versionControlBaseURL to default and completes with `.failure`.
+@MainActor
 enum ColocationResolver {
     private static let cacheKey = "ATVersionControl.cache.colocationType"
 
-    static func resolve(applicationName: String, version: String, completion: @escaping (GetEndpointsResult) -> Void) {
+    static func resolve(
+        applicationName: String,
+        version: String,
+        completion: @MainActor @escaping (GetEndpointsResult) -> Void
+    ) {
         tryLanes(lanesInTryOrder(), applicationName: applicationName, version: version, completion: completion)
     }
 
@@ -32,7 +37,7 @@ enum ColocationResolver {
         _ lanes: [ColocationLane],
         applicationName: String,
         version: String,
-        completion: @escaping (GetEndpointsResult) -> Void
+        completion: @MainActor @escaping (GetEndpointsResult) -> Void
     ) {
         guard let lane = lanes.first else {
             ATUrl.versionControlBaseURL = ATUrl.defaultVersionControlBaseURL
@@ -59,7 +64,7 @@ enum ColocationResolver {
         lane: ColocationLane,
         applicationName: String,
         version: String,
-        completion: @escaping (ColocationInfo?) -> Void
+        completion: @MainActor @escaping (ColocationInfo?) -> Void
     ) {
         let url: String
         switch lane {
@@ -79,11 +84,15 @@ enum ColocationResolver {
                 ]
             ], ignoreParameterCreator: true)
             .send { response in
-                completion(ColocationInfo.from(response: response))
-            }
+                MainActor.assumeIsolated {
+                    completion(ColocationInfo.from(response: response))
+                }            }
     }
 
-    private static func finish(_ result: GetEndpointsResult, completion: @escaping (GetEndpointsResult) -> Void) {
+    private static func finish(
+        _ result: GetEndpointsResult,
+        completion: @MainActor @escaping (GetEndpointsResult) -> Void
+    ) {
         DispatchQueue.main.async {
             completion(result)
         }

--- a/ATVersionControl/Classes/Model/ColocationEndpoint.swift
+++ b/ATVersionControl/Classes/Model/ColocationEndpoint.swift
@@ -4,20 +4,18 @@
 //
 //  Created by Amir on 7/13/26.
 //
-import SwiftBooster
-
 public class ColocationEndpoint {
     public var name = ""
     public var baseURL = ""
 
-    class func from(json object: JSONObject?) -> ColocationEndpoint? {
+    class func from(json object: [String: Any]?) -> ColocationEndpoint? {
         guard let object = object else {
             return nil
         }
 
         let result = ColocationEndpoint()
-        result.name = getValue(input: object, subscripts: "Name") ?? ""
-        result.baseURL = getValue(input: object, subscripts: "BaseUrl") ?? ""
+        result.name = object["Name"] as? String ?? ""
+        result.baseURL = object["BaseUrl"] as? String ?? ""
 
         guard !result.name.isEmpty, !result.baseURL.isEmpty else {
             return nil

--- a/ATVersionControl/Classes/Model/ColocationEndpoint.swift
+++ b/ATVersionControl/Classes/Model/ColocationEndpoint.swift
@@ -4,16 +4,21 @@
 //
 //  Created by Amir on 7/13/26.
 //
-public class ColocationEndpoint {
+public struct ColocationEndpoint: Decodable, Sendable {
     public var name = ""
     public var baseURL = ""
 
-    class func from(json object: [String: Any]?) -> ColocationEndpoint? {
+    enum CodingKeys: String, CodingKey {
+        case name = "Name"
+        case baseURL = "BaseUrl"
+    }
+
+    static func from(json object: [String: Any]?) -> ColocationEndpoint? {
         guard let object = object else {
             return nil
         }
 
-        let result = ColocationEndpoint()
+        var result = ColocationEndpoint()
         result.name = object["Name"] as? String ?? ""
         result.baseURL = object["BaseUrl"] as? String ?? ""
 

--- a/ATVersionControl/Classes/Model/ColocationInfo.swift
+++ b/ATVersionControl/Classes/Model/ColocationInfo.swift
@@ -5,17 +5,21 @@
 
 import AyanTechNetworkingLibrary
 
-class ColocationInfo {
+struct ColocationInfo: Decodable, Sendable {
     static let versionControlEndpointName = "VersionControl"
 
     var endpoints = [ColocationEndpoint]()
 
-    class func from(response: ATResponse) -> ColocationInfo? {
+    enum CodingKeys: String, CodingKey {
+        case endpoints = "EndpointList"
+    }
+
+    static func from(response: ATResponse) -> ColocationInfo? {
         guard response.isSuccess, let parameters = response.parametersJsonObject else {
             return nil
         }
 
-        let result = ColocationInfo()
+        var result = ColocationInfo()
 
         if let objects = parameters["EndpointList"] as? [[String: Any]] {
             result.endpoints = objects.compactMap { ColocationEndpoint.from(json: $0) }

--- a/ATVersionControl/Classes/Model/ColocationInfo.swift
+++ b/ATVersionControl/Classes/Model/ColocationInfo.swift
@@ -4,7 +4,6 @@
 //
 
 import AyanTechNetworkingLibrary
-import SwiftBooster
 
 class ColocationInfo {
     static let versionControlEndpointName = "VersionControl"
@@ -18,7 +17,7 @@ class ColocationInfo {
 
         let result = ColocationInfo()
 
-        if let objects: [JSONObject] = getValue(input: parameters, subscripts: "EndpointList") {
+        if let objects = parameters["EndpointList"] as? [[String: Any]] {
             result.endpoints = objects.compactMap { ColocationEndpoint.from(json: $0) }
         }
 

--- a/ATVersionControl/Classes/Model/UpdateStatus.swift
+++ b/ATVersionControl/Classes/Model/UpdateStatus.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public enum UpdateStatus: String {
+public enum UpdateStatus: String, Decodable, Sendable {
     case notRequired = "NotRequired"
     case optional = "Optional"
     case mandatory = "Mandatory"

--- a/ATVersionControl/Classes/Model/Utils.swift
+++ b/ATVersionControl/Classes/Model/Utils.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 
+@MainActor
 class Utils {
     class func getTopMostViewController() -> UIViewController? {
         var topController = UIApplication.shared.keyWindow?.rootViewController

--- a/ATVersionControl/Classes/Model/Utils.swift
+++ b/ATVersionControl/Classes/Model/Utils.swift
@@ -11,7 +11,12 @@ import UIKit
 @MainActor
 class Utils {
     class func getTopMostViewController() -> UIViewController? {
-        var topController = UIApplication.shared.keyWindow?.rootViewController
+        var topController = UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .first(where: { $0.activationState == .foregroundActive })?
+            .windows
+            .first(where: \.isKeyWindow)?
+            .rootViewController
         
         while topController?.presentedViewController != nil {
             topController = topController?.presentedViewController

--- a/ATVersionControl/Classes/Model/VersionControl.swift
+++ b/ATVersionControl/Classes/Model/VersionControl.swift
@@ -9,6 +9,7 @@
 import UIKit
 import AyanTechNetworkingLibrary
 
+@MainActor
 public protocol VersionControlDelegate: AnyObject {
     func versionControlCompletedSuccessfully()
     func versionControlDidFinish(with error: String)

--- a/ATVersionControl/Classes/Model/VersionControl.swift
+++ b/ATVersionControl/Classes/Model/VersionControl.swift
@@ -8,7 +8,6 @@
 
 import UIKit
 import AyanTechNetworkingLibrary
-import SwiftBooster
 
 public protocol VersionControlDelegate: AnyObject {
     func versionControlCompletedSuccessfully()
@@ -22,7 +21,7 @@ open class VersionControl {
     public var applicationName = ""
     public var version = ""
     public var categoryName = ""
-    public var extraInfo = JSONObject()
+    public var extraInfo: [String: Any] = [:]
     public weak var delegate: VersionControlDelegate?
     
     private var updateStatus: UpdateStatus = .notRequired
@@ -97,7 +96,9 @@ open class VersionControl {
     
     private func handleCheckVersionResponse(_ response: ATResponse) {
         if response.isSuccess {
-            if let updateStatus = UpdateStatus(rawValue: getValue(input: response.parametersJsonObject, subscripts: "UpdateStatus") ?? ""), updateStatus != .notRequired {
+            if let updateStatusValue = response.parametersJsonObject?["UpdateStatus"] as? String,
+               let updateStatus = UpdateStatus(rawValue: updateStatusValue),
+               updateStatus != .notRequired {
                 self.getLastVersion() { versionInfo, error in
                     if let info = versionInfo {
                         self.showUpdateDialog(updateStatus: updateStatus, versionInfo: info)

--- a/ATVersionControl/Classes/Model/VersionControl.swift
+++ b/ATVersionControl/Classes/Model/VersionControl.swift
@@ -21,7 +21,7 @@ open class VersionControl {
     public var applicationName = ""
     public var version = ""
     public var categoryName = ""
-    public var extraInfo: [String: Any] = [:]
+    public var extraInfo: [String: String] = [:]
     public weak var delegate: VersionControlDelegate?
     
     private var updateStatus: UpdateStatus = .notRequired

--- a/ATVersionControl/Classes/Model/VersionControl.swift
+++ b/ATVersionControl/Classes/Model/VersionControl.swift
@@ -22,6 +22,7 @@ open class VersionControl {
     public var version = ""
     public var categoryName = ""
     public var extraInfo: [String: String] = [:]
+    public var networkingConfiguration: ConfigurationV2 = .init(timeout: 30)
     public weak var delegate: VersionControlDelegate?
     
     private var updateStatus: UpdateStatus = .notRequired

--- a/ATVersionControl/Classes/Model/VersionControl.swift
+++ b/ATVersionControl/Classes/Model/VersionControl.swift
@@ -15,6 +15,7 @@ public protocol VersionControlDelegate: AnyObject {
     func versionControlDidFinish(with error: String)
 }
 
+@MainActor
 open class VersionControl {
     fileprivate static var instance: VersionControl?
     
@@ -87,8 +88,10 @@ open class VersionControl {
                 ignoreParameterCreator: true
             )
             .send { [weak self] response in
-                guard let self else { return }
-                self.handleCheckVersionResponse(response)
+                MainActor.assumeIsolated {
+                    guard let self else { return }
+                    self.handleCheckVersionResponse(response)
+                }
             }
     }
     
@@ -110,7 +113,9 @@ open class VersionControl {
         }
     }
     
-    private func getLastVersion(_ completionHandler: ((VersionInfo?, ATError?) -> Void)? = nil) {
+    private func getLastVersion(
+        _ completionHandler: (@MainActor (VersionInfo?, ATError?) -> Void)? = nil
+    ) {
         ATRequest.request(url: ATUrl.getLastVersion, method: .post)
         .setJsonBody(body: [
             "Parameters": [
@@ -121,11 +126,13 @@ open class VersionControl {
                 "ExtraInfo": self.extraInfo
             ]
         ], ignoreParameterCreator: true)
-            .send { (response) in
-                if let versionInfo = VersionInfo.from(json: response.parametersJsonObject) {
-                    completionHandler?(versionInfo, nil)
-                } else {
-                    completionHandler?(nil, response.error ?? .generalError)
+            .send { response in
+                MainActor.assumeIsolated {
+                    if let versionInfo = VersionInfo.from(json: response.parametersJsonObject) {
+                        completionHandler?(versionInfo, nil)
+                    } else {
+                        completionHandler?(nil, response.error ?? .generalError)
+                    }
                 }
         }
     }

--- a/ATVersionControl/Classes/Model/VersionInfo.swift
+++ b/ATVersionControl/Classes/Model/VersionInfo.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public class VersionInfo {
+public struct VersionInfo: Decodable, Sendable {
     public var acceptButtonText = ""
     public var body = ""
     public var changeLogs = [String]()
@@ -17,13 +17,24 @@ public class VersionInfo {
     public var rejectButtonText = ""
     public var textToShare = ""
     public var title = ""
-    
-    class func from(json object: [String: Any]?) -> VersionInfo? {
+
+    enum CodingKeys: String, CodingKey {
+        case acceptButtonText = "AcceptButtonText"
+        case body = "Body"
+        case changeLogs = "ChangeLogs"
+        case link = "Link"
+        case linkType = "LinkType"
+        case rejectButtonText = "RejectButtonText"
+        case textToShare = "TextToShare"
+        case title = "Title"
+    }
+
+    static func from(json object: [String: Any]?) -> VersionInfo? {
         guard let object = object else {
             return nil
         }
         
-        let result = VersionInfo()
+        var result = VersionInfo()
         result.acceptButtonText = object["AcceptButtonText"] as? String ?? ""
         result.body = object["Body"] as? String ?? ""
         result.changeLogs = object["ChangeLogs"] as? [String] ?? []

--- a/ATVersionControl/Classes/Model/VersionInfo.swift
+++ b/ATVersionControl/Classes/Model/VersionInfo.swift
@@ -7,7 +7,6 @@
 //
 
 import Foundation
-import SwiftBooster
 
 public class VersionInfo {
     public var acceptButtonText = ""
@@ -19,20 +18,20 @@ public class VersionInfo {
     public var textToShare = ""
     public var title = ""
     
-    class func from(json object: JSONObject?) -> VersionInfo? {
+    class func from(json object: [String: Any]?) -> VersionInfo? {
         guard let object = object else {
             return nil
         }
         
         let result = VersionInfo()
-        result.acceptButtonText = getValue(input: object, subscripts: "AcceptButtonText") ?? ""
-        result.body = getValue(input: object, subscripts: "Body") ?? ""
-        result.changeLogs = getValue(input: object, subscripts: "ChangeLogs") ?? []
-        result.link = getValue(input: object, subscripts: "Link") ?? ""
-        result.linkType = getValue(input: object, subscripts: "LinkType") ?? ""
-        result.rejectButtonText = getValue(input: object, subscripts: "RejectButtonText") ?? ""
-        result.textToShare = getValue(input: object, subscripts: "TextToShare") ?? ""
-        result.title = getValue(input: object, subscripts: "Title") ?? ""
+        result.acceptButtonText = object["AcceptButtonText"] as? String ?? ""
+        result.body = object["Body"] as? String ?? ""
+        result.changeLogs = object["ChangeLogs"] as? [String] ?? []
+        result.link = object["Link"] as? String ?? ""
+        result.linkType = object["LinkType"] as? String ?? ""
+        result.rejectButtonText = object["RejectButtonText"] as? String ?? ""
+        result.textToShare = object["TextToShare"] as? String ?? ""
+        result.title = object["Title"] as? String ?? ""
         return result
     }
 }

--- a/Docs/ROADMAP.md
+++ b/Docs/ROADMAP.md
@@ -1,0 +1,24 @@
+# Roadmap
+
+This is a suggested roadmap for future work. It does not describe the current version.
+
+## Next major version
+
+The next major version should use Networking V2 and Combine as the main implementation while keeping the package simple.
+
+### Legacy code to remove
+
+- Remove `checkVersion(delegate:)`, `getEndpoints(completion:)`, and `shareAppLink(_:)` after their backward-compatibility period.
+- Remove the private callback-based `getLastVersion` implementation.
+- Remove `VersionControlDelegate` and its `delegate` property.
+- Remove Networking V1 requests and related files.
+- Remove `Colocation.swift` and `GetEndpointsResultEnum.swift`.
+- Remove `from(json:)` and `from(response:)` helpers after Networking V1 is removed.
+
+### Publishers and UI
+
+- Keep `checkVersionPublisher()`, `getLastVersionPublisher()`, `getEndpointsPublisher()`, and `shareAppLinkPublisher()`.
+- Rename these methods to remove the `Publisher` suffix because publishers will be the only source.
+- Keep data publishers focused on returning data and remove dialog presentation from them.
+- Move optional update dialogs and share sheets to a separate UI convenience layer.
+

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -1,5 +1,5 @@
 use_frameworks!
-platform :ios, '11.0'
+platform :ios, '13.0'
 
 target 'ATVersionControl_Example' do
   pod 'ATVersionControl', :path => '../'

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/AyanTech/SwiftBooster", .branch("master")),
-        .package(url: "https://github.com/AyanTech/AyanTechNetworkingLibrary-iOS", .upToNextMajor(from: "1.8.0")),
+        .package(url: "https://github.com/AyanTech/AyanTechNetworkingLibrary-iOS", .upToNextMajor(from: "2.0.0")),
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -15,15 +15,13 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/AyanTech/SwiftBooster", .branch("master")),
         .package(url: "https://github.com/AyanTech/AyanTechNetworkingLibrary-iOS", .upToNextMajor(from: "2.0.0")),
     ],
     targets: [
         .target(
             name: "ATVersionControl",
             dependencies: [
-                .product(name: "AyanTechNetworkingLibrary", package: "AyanTechNetworkingLibrary-iOS"),
-                "SwiftBooster"
+                .product(name: "AyanTechNetworkingLibrary", package: "AyanTechNetworkingLibrary-iOS")
             ],
             path: "ATVersionControl"
         ),

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:6.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "ATVersionControl",
     platforms: [
-        .iOS(.v12),
+        .iOS(.v13),
     ],
     products: [
         .library(

--- a/README.md
+++ b/README.md
@@ -5,64 +5,145 @@
 
 <span style="color:red;">*</span> *app should be registered in AyanTechServers*
 
+## Requirements
+
+- iOS 13.0+
+- Swift 6.0+
+- Xcode 16.0+
+- AyanTechNetworkingLibrary 2.x
+
 ## Usage
 
-#### Version control
+### Configuration
 
-To configure the parameters use this:
 ```swift
 VersionControl.shared.applicationName = "MyAppName"
 VersionControl.shared.categoryName = "cat"
-VersionControl.shared.version = "1.0.0" //default version is CFBundleShortVersionString
-VersionControl.shared.extraInfo["Token"] = "Test" //Json object and optional
+VersionControl.shared.version = "1.0.0" // Defaults to CFBundleShortVersionString
+VersionControl.shared.extraInfo["Token"] = "Test"
 ```
 
-And to check the latest version wherever you like just call:
+### Combine
+
+Resolve the app endpoints first, then check its version. Keep each subscription alive until it completes:
+
 ```swift
-VersionControl.shared.checkVersion()
+import Combine
+
+@MainActor
+final class VersionControlFlow {
+    private let versionControl = VersionControl.shared
+    private var endpointsCancellable: AnyCancellable?
+    private var versionCheckCancellable: AnyCancellable?
+
+    func start() {
+        resolveEndpoints()
+    }
+
+    private func resolveEndpoints() {
+        endpointsCancellable?.cancel()
+
+        endpointsCancellable = versionControl.getEndpointsPublisher()
+            .sink(
+                receiveCompletion: { [weak self] completion in
+                    if case .failure(let error) = completion {
+                        // Apply the app's default endpoint configuration.
+                        print(error.message)
+                    }
+                    self?.checkVersion()
+                },
+                receiveValue: { endpoints in
+                    // Apply the resolved endpoints to the app's services.
+                    print(endpoints)
+                }
+            )
+    }
+
+    func checkVersion() {
+        versionCheckCancellable?.cancel()
+
+        versionCheckCancellable = versionControl.checkVersionPublisher()
+            .sink(
+                receiveCompletion: { completion in
+                    if case .failure(let error) = completion {
+                        // Show an error or continue according to app requirements.
+                        print(error.message)
+                    }
+                },
+                receiveValue: { status in
+                    switch status {
+                    case .notRequired:
+                        // Navigate to the app.
+                        break
+                    case .optional, .mandatory:
+                        // The package presents the update dialog automatically.
+                        break
+                    }
+                }
+            )
+    }
+}
 ```
-It automatically shows an update dialog if there is one, and handle the actions.
 
-#### Custom update UI (optional)
+Endpoint resolution is optional. If the app does not use colocation discovery, call `checkVersion()` directly.
 
-Call `useShared` once at app launch **before** any `VersionControl.shared` use. Subclass and override `showUpdateDialog` to replace the default alert (e.g. bottom sheet). If you do not call `useShared`, behavior is unchanged.
+`checkVersionPublisher()` completes after presenting an optional or mandatory update dialog; it does not wait for the user's decision. Set `VersionControl.shared.delegate` to handle the current optional-update "Later" action.
+
+### Latest version information
+
+```swift
+versionControl.getLastVersionPublisher()
+    .sink(
+        receiveCompletion: { print($0) },
+        receiveValue: { versionInfo in
+            print(versionInfo.title)
+        }
+    )
+    .store(in: &cancellables)
+```
+
+### Share application
+
+```swift
+versionControl.shareAppLinkPublisher()
+    .sink(
+        receiveCompletion: { print($0) },
+        receiveValue: { _ in }
+    )
+    .store(in: &cancellables)
+```
+
+`shareAppLinkPublisher()` automatically presents `UIActivityViewController`.
+
+### Custom update UI (optional)
+
+Call `useShared` once at app launch, before accessing `VersionControl.shared`. Override `showUpdateDialog` to replace the default alert.
 
 ```swift
 final class AppVersionControl: VersionControl {
     override func showUpdateDialog(updateStatus: UpdateStatus, versionInfo: VersionInfo) {
-        // Your UI — use versionInfo.title, .body, .link, button texts, etc.
+        // Present custom update UI.
     }
 }
 
-// e.g. AppDelegate.application(_:didFinishLaunchingWithOptions:)
 VersionControl.useShared(AppVersionControl())
 ```
 
-#### Endpoint resolution (optional)
+### Legacy compatibility
 
-Using `getEndpoints` is **arbitrary** — only add it if your app needs colocation discovery.
-
-Call `getEndpoints`, then `checkVersion` yourself — the package does not chain them. If you never call `getEndpoints`, behavior is unchanged: version checks use `defaultVersionControlBaseURL` for `CheckVersion` / `GetLastVersion`.
+The callback APIs remain temporarily available for backward compatibility:
 
 ```swift
-VersionControl.shared.applicationName = "MyAppName"
+VersionControl.shared.checkVersion()
+
 VersionControl.shared.getEndpoints { result in
-    switch result {
-    case .success(let endpoints):
-        break // app uses endpoints as needed
-    case .failure:
-        break
-    }
-    VersionControl.shared.checkVersion()
+    print(result)
+}
+
+VersionControl.shared.shareAppLink { error in
+    print(error as Any)
 }
 ```
-
-#### Share application
-Just call:
-```swift
-VersionControl.shared.shareAppLink() 
-```
-It automatically shows the `UIActivityViewController` for sharing app link or text.
 
 ## Installation
 


### PR DESCRIPTION
## Task

Migrate ATVersionControl to Swift 6 and Networking V2.

## Changes

- Raised the minimum Swift version to 6.0.
- Fixed concurrency warnings.
- Raised the minimum iOS version to 13.0.
- Updated AyanTechNetworkingLibrary to 2.0.0.
- Added Combine-based version control, colocation, and sharing APIs.
- Kept legacy callback APIs for backward compatibility.
- Converted models to Decodable, Sendable structs to reuse them in Combine.
- Added main-actor isolation for UI-related APIs and delegates.
- Added configurable Networking V2 request settings.
- Removed SwiftBooster and the unused PopupDialog dependency.
- Raised the podspec version to 0.7.0.
- Removed the unused assets folder.
- Updated the README with Combine usage.
- Added a suggested roadmap document for the next major version.

## Testing

- Tested the legacy callback flow in a consuming application.
- Tested the new Combine flow in a consuming application.

## Risks / Notes

- Legacy APIs remain temporarily available and should be removed in a future major version.
- checkVersionPublisher() completes after presenting the update dialog, so Combine consumers must still use VersionControlDelegate to handle optional update rejection and continue into the app. This behavior is documented in the README; a future version should extract UI from the publisher and provide a fully reactive user-decision API.
- The podspec version was already 0.6.0, so it was changed to 0.7.0 for this release. Please create the 0.7.0 SPM tag after the merge.